### PR TITLE
For Payment objects allow iban and bic to be accessed.

### DIFF
--- a/lib/paymill/models/payment.rb
+++ b/lib/paymill/models/payment.rb
@@ -3,7 +3,8 @@ module Paymill
     include Restful::Delete
 
     attr_reader :type, :client, :card_type, :country, :expire_month, :expire_year, :card_holder,
-                :last4, :is_recurring, :is_usable_for_preauthorization, :code, :holder, :account
+                :last4, :is_recurring, :is_usable_for_preauthorization, :code, :holder, :account,
+                :iban, :bic
 
     protected
     def self.allowed_arguments

--- a/spec/paymill/models/payment_spec.rb
+++ b/spec/paymill/models/payment_spec.rb
@@ -29,6 +29,8 @@ module Paymill
         expect( payment.created_at ).to be_a Time
         expect( payment.updated_at ).to be_a Time
         expect( payment.app_id ).to be_nil
+        expect( payment.iban ).to be_nil
+        expect( payment.bic ).to be_nil
 
         # TODO[VNi]: be more descriptive
       end
@@ -61,6 +63,8 @@ module Paymill
           expect( payment.created_at ).to be_a Time
           expect( payment.updated_at ).to be_a Time
           expect( payment.app_id ).to be_nil
+          expect( payment.iban ).to be_nil
+          expect( payment.bic ).to be_nil
         end
 
         it 'should create client with token and client', :vcr do
@@ -85,6 +89,8 @@ module Paymill
           expect( payment.created_at ).to be_a Time
           expect( payment.updated_at ).to be_a Time
           expect( payment.app_id ).to be_nil
+          expect( payment.iban ).to be_nil
+          expect( payment.bic ).to be_nil
         end
 
         it 'should throw exception when creating a clinent with invalid token', :vcr do
@@ -126,6 +132,8 @@ module Paymill
           expect( payment.created_at ).to be_a Time
           expect( payment.updated_at ).to be_a Time
           expect( payment.app_id ).to be_nil
+          expect( payment.iban ).to be_nil
+          expect( payment.bic ).to be_nil
         end
 
         it 'should create client with token and client', :vcr do
@@ -147,6 +155,8 @@ module Paymill
           expect( payment.created_at ).to be_a Time
           expect( payment.updated_at ).to be_a Time
           expect( payment.app_id ).to be_nil
+          expect( payment.iban ).to be_nil
+          expect( payment.bic ).to be_nil
         end
       end
     end


### PR DESCRIPTION
Hi there,

the Payment object did not support iban and bic to be accessed. I added the respective :attr_accessors.

Best,
Tobias