### PR TITLE
Speed up builds and test on newer Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
-  - 2.0.0
+  - 2.0
+  - 2.1
+  - 2.2


### PR DESCRIPTION
Currently builds are failing because of https://github.com/paymill/paymill-ruby/issues/9 but when you fix it, it should speed up the builds.
Also all Ruby versions, that are stated in Readme should be tested