### PR TITLE
Do not try to cast every value of JSON to integer

### DIFF
--- a/lib/paymill/models/base.rb
+++ b/lib/paymill/models/base.rb
@@ -36,7 +36,7 @@ module Paymill
         when 'Hash'
           instance_variable_set( "@#{key}", objectize( key, value ) )
         else
-          instance_variable_set( "@#{key}", (Integer( value ) rescue value) )
+          instance_variable_set( "@#{key}", value )
         end
       end
     end

--- a/spec/paymill/models/offer_spec.rb
+++ b/spec/paymill/models/offer_spec.rb
@@ -11,7 +11,7 @@ module Paymill
 
         expect( offer.id ).to be_a String
         expect( offer.name ).to eq 'Superabo'
-        expect( offer.amount ).to be 4200
+        expect( offer.amount ).to eq 4200.to_s # bug in API
         expect( offer.currency ).to eq 'EUR'
         expect( offer.interval ).to eq '1 MONTH'
         expect( offer.trial_period_days ).to be 0
@@ -28,7 +28,7 @@ module Paymill
 
         expect( offer.id ).to be_a String
         expect( offer.name ).to eq 'sabo'
-        expect( offer.amount ).to eq 4200
+        expect( offer.amount ).to eq 4200.to_s # bug in API
         expect( offer.currency ).to eq 'EUR'
         expect( offer.interval ).to eq '1 MONTH'
         expect( offer.trial_period_days ).to be 30
@@ -85,7 +85,7 @@ module Paymill
 
         expect( offer.id ).to eq offer_id
         expect( offer.name ).to eq 'Superabo'
-        expect( offer.amount ).to eq 4200
+        expect( offer.amount ).to eq 4200.to_s # bug in API
         expect( offer.currency ).to eq 'EUR'
         expect( offer.interval ).to eq '1 MONTH'
         expect( offer.trial_period_days ).to be 30
@@ -104,7 +104,7 @@ module Paymill
 
         expect( offer.id ).to eq offer_id
         expect( offer.name ).to eq 'Superabo'
-        expect( offer.amount ).to eq 900
+        expect( offer.amount ).to eq 900.to_s # bug in API
         expect( offer.currency ).to eq 'USD'
         expect( offer.interval ).to eq '1 MONTH'
         expect( offer.trial_period_days ).to be 30
@@ -122,7 +122,7 @@ module Paymill
 
         expect( offer.id ).to eq offer_id
         expect( offer.name ).to eq 'Superabo'
-        expect( offer.amount ).to eq 1000
+        expect( offer.amount ).to eq 1000.to_s # bug in API
         expect( offer.currency ).to eq 'USD'
         expect( offer.interval ).to eq '1 MONTH'
         expect( offer.trial_period_days ).to be 30

--- a/spec/paymill/models/payment_spec.rb
+++ b/spec/paymill/models/payment_spec.rb
@@ -30,10 +30,10 @@ module Paymill
           expect( payment.card_type ). to eq 'visa'
 
           expect( payment.country ).to be_nil
-          expect( payment.expire_month ).to be 12
-          expect( payment.expire_year ).to be 2015
+          expect( payment.expire_month ).to eq '12'
+          expect( payment.expire_year ).to eq '2015'
           expect( payment.card_holder ).to eq 'Max Mustermann'
-          expect( payment.last4 ).to eq 1111
+          expect( payment.last4 ).to eq '1111'
           expect( payment.is_recurring ).to be true
           expect( payment.is_usable_for_preauthorization ).to be true
 
@@ -54,10 +54,10 @@ module Paymill
           expect( payment.card_type ).to eq 'visa'
 
           expect( payment.country ).to be_nil
-          expect( payment.expire_month ).to eq 12
-          expect( payment.expire_year ).to eq 2015
+          expect( payment.expire_month ).to eq '12'
+          expect( payment.expire_year ).to eq '2015'
           expect( payment.card_holder ).to eq 'Max Mustermann'
-          expect( payment.last4 ).to eq 1111
+          expect( payment.last4 ).to eq '1111'
           expect( payment.is_recurring ).to be true
           expect( payment.is_usable_for_preauthorization ).to be true
 
@@ -101,10 +101,10 @@ module Paymill
           expect( payment.card_type ). to eq 'visa'
 
           expect( payment.country ).to be nil
-          expect( payment.expire_month ).to eq 12
-          expect( payment.expire_year ).to eq 2015
+          expect( payment.expire_month ).to eq '12'
+          expect( payment.expire_year ).to eq '2015'
           expect( payment.card_holder ).to eq 'Max Mustermann'
-          expect( payment.last4 ).to eq 1111
+          expect( payment.last4 ).to eq '1111'
           expect( payment.is_recurring ).to be true
           expect( payment.is_usable_for_preauthorization ).to be true
 

--- a/spec/paymill/models/preauthorization_spec.rb
+++ b/spec/paymill/models/preauthorization_spec.rb
@@ -28,7 +28,7 @@ module Paymill
         expect( preauthorization ).to be_a Preauthorization
 
         expect( preauthorization.id ).to be_a String
-        expect( preauthorization.amount ).to be amount
+        expect( preauthorization.amount ).to eq amount.to_s # bug in API
         expect( preauthorization.currency ).to eq currency
         expect( preauthorization.description ).to be_nil
         expect( preauthorization.status ).to eq 'closed'
@@ -43,10 +43,10 @@ module Paymill
         expect( preauthorization.payment.card_type ). to eq 'visa'
 
         expect( preauthorization.payment.country ).to be_nil
-        expect( preauthorization.payment.expire_month ).to eq 12
-        expect( preauthorization.payment.expire_year ).to eq 2015
+        expect( preauthorization.payment.expire_month ).to eq '12'
+        expect( preauthorization.payment.expire_year ).to eq '2015'
         expect( preauthorization.payment.card_holder ).to eq 'John Rambo'
-        expect( preauthorization.payment.last4 ).to eq 1111
+        expect( preauthorization.payment.last4 ).to eq '1111'
         expect( preauthorization.payment.is_recurring ).to be true
         expect( preauthorization.payment.is_usable_for_preauthorization ).to be true
 
@@ -67,7 +67,7 @@ module Paymill
         expect( preauthorization ).to be_a Preauthorization
 
         expect( preauthorization.id ).to be_a String
-        expect( preauthorization.amount ).to be amount
+        expect( preauthorization.amount ).to eq amount.to_s # bug in API
         expect( preauthorization.currency ).to eq currency
         expect( preauthorization.description ).to be_nil
         expect( preauthorization.status ).to eq 'closed'
@@ -83,10 +83,10 @@ module Paymill
         expect( preauthorization.payment.card_type ). to eq 'visa'
 
         expect( preauthorization.payment.country ).to be_nil
-        expect( preauthorization.payment.expire_month ).to eq 12
-        expect( preauthorization.payment.expire_year ).to eq 2015
+        expect( preauthorization.payment.expire_month ).to eq '12'
+        expect( preauthorization.payment.expire_year ).to eq '2015'
         expect( preauthorization.payment.card_holder ).to eq 'John Rambo'
-        expect( preauthorization.payment.last4 ).to eq 1111
+        expect( preauthorization.payment.last4 ).to eq '1111'
         expect( preauthorization.payment.is_recurring ).to be true
         expect( preauthorization.payment.is_usable_for_preauthorization ).to be true
 
@@ -109,7 +109,7 @@ module Paymill
         expect( preauthorization ).to be_a Preauthorization
 
         expect( preauthorization.id ).to be_a String
-        expect( preauthorization.amount ).to be amount
+        expect( preauthorization.amount ).to eq amount.to_s # bug in API
         expect( preauthorization.currency ).to eq currency
         expect( preauthorization.description ).to eq 'The Italian Stallion'
         expect( preauthorization.status ).to eq 'closed'
@@ -125,10 +125,10 @@ module Paymill
         expect( preauthorization.payment.card_type ). to eq 'visa'
 
         expect( preauthorization.payment.country ).to be_nil
-        expect( preauthorization.payment.expire_month ).to eq 12
-        expect( preauthorization.payment.expire_year ).to eq 2015
+        expect( preauthorization.payment.expire_month ).to eq '12'
+        expect( preauthorization.payment.expire_year ).to eq '2015'
         expect( preauthorization.payment.card_holder ).to eq 'John Rambo'
-        expect( preauthorization.payment.last4 ).to eq 1111
+        expect( preauthorization.payment.last4 ).to eq '1111'
         expect( preauthorization.payment.is_recurring ).to be true
         expect( preauthorization.payment.is_usable_for_preauthorization ).to be true
 

--- a/spec/paymill/models/refund_spec.rb
+++ b/spec/paymill/models/refund_spec.rb
@@ -77,7 +77,7 @@ module Paymill
         expect( refund.livemode ).to be false
         expect( refund.created_at ).to be_a Time
         expect( refund.updated_at ).to be_a Time
-        expect( refund.response_code ).to be 20000
+        expect( refund.response_code ).to eq '20000'
         expect( refund.transaction ).not_to be_nil
         expect( refund.app_id ).to be_nil
       end

--- a/spec/paymill/models/subscription_spec.rb
+++ b/spec/paymill/models/subscription_spec.rb
@@ -67,7 +67,7 @@ module Paymill
         expect( subscription ).to be_a Subscription
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be amount
+        expect( subscription.offer.amount ).to eq amount.to_s # bug in API
         expect( subscription.offer.currency ).to eq currency
         expect( subscription.offer.interval ).to eq interval
         expect( subscription.livemode ).to be false
@@ -99,7 +99,7 @@ module Paymill
         expect( subscription ).to be_a Subscription
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be amount
+        expect( subscription.offer.amount ).to eq amount.to_s # bug in API
         expect( subscription.offer.currency ).to eq currency
         expect( subscription.offer.interval ).to eq interval
         expect( subscription.livemode ).to be false
@@ -165,7 +165,7 @@ module Paymill
 
         expect( subscription.id ).to be_a String
         expect( subscription.mandate_reference ).to eq 'Terminator'
-        expect( subscription.offer.amount ).to be amount
+        expect( subscription.offer.amount ).to eq amount.to_s # bug in API
         expect( subscription.offer.currency ).to eq currency
         expect( subscription.offer.interval ).to eq interval
         expect( subscription.offer.name ).to eq 'Basic Stallion'
@@ -363,12 +363,12 @@ module Paymill
         subscription.update_offer_without_changes( new_offer )
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be new_offer.amount
+        expect( subscription.offer.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.offer.currency ).to eq new_offer.currency
         expect( subscription.offer.interval ).to eq new_offer.interval
         expect( subscription.offer.name ).to eq new_offer.name
         expect( subscription.livemode ).to be false
-        expect( subscription.amount ).to be new_offer.amount
+        expect( subscription.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.temp_amount ).to be_nil
         expect( subscription.currency ).to eq new_offer.currency
         expect( subscription.name ).to eq new_offer.name
@@ -396,12 +396,12 @@ module Paymill
         subscription.update_offer_with_refund( new_offer )
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be new_offer.amount
+        expect( subscription.offer.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.offer.currency ).to eq new_offer.currency
         expect( subscription.offer.interval ).to eq new_offer.interval
         expect( subscription.offer.name ).to eq new_offer.name
         expect( subscription.livemode ).to be false
-        expect( subscription.amount ).to be new_offer.amount
+        expect( subscription.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.temp_amount ).to be_nil
         expect( subscription.currency ).to eq new_offer.currency
         expect( subscription.name ).to eq new_offer.name
@@ -429,12 +429,12 @@ module Paymill
         subscription.update_offer_with_refund_and_capture_date( new_offer )
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be new_offer.amount
+        expect( subscription.offer.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.offer.currency ).to eq new_offer.currency
         expect( subscription.offer.interval ).to eq new_offer.interval
         expect( subscription.offer.name ).to eq new_offer.name
         expect( subscription.livemode ).to be false
-        expect( subscription.amount ).to be new_offer.amount
+        expect( subscription.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.temp_amount ).to be_nil
         expect( subscription.currency ).to eq new_offer.currency
         expect( subscription.name ).to eq new_offer.name
@@ -550,12 +550,12 @@ module Paymill
           subscription = Subscription.create( payment: @payment, offer: offer, name: 'To Delete' ).cancel
 
           expect( subscription.id ).to be_a String
-          expect( subscription.offer.amount ).to be offer.amount
+          expect( subscription.offer.amount.to_s ).to eq offer.amount # bug in API
           expect( subscription.offer.currency ).to eq offer.currency
           expect( subscription.offer.interval ).to eq offer.interval
           expect( subscription.offer.name ).to eq offer.name
           expect( subscription.livemode ).to be false
-          expect( subscription.amount ).to be offer.amount
+          expect( subscription.amount.to_s ).to eq offer.amount # bug in API
           expect( subscription.temp_amount ).to be_nil
           expect( subscription.currency ).to eq offer.currency
           expect( subscription.name ).to eq 'To Delete'
@@ -578,12 +578,12 @@ module Paymill
         subscription = Subscription.create( payment: @payment, offer: offer, name: 'To Delete' ).remove
 
         expect( subscription.id ).to be_a String
-        expect( subscription.offer.amount ).to be offer.amount
+        expect( subscription.offer.amount.to_s ).to eq offer.amount # bug in API
         expect( subscription.offer.currency ).to eq offer.currency
         expect( subscription.offer.interval ).to eq offer.interval
         expect( subscription.offer.name ).to eq offer.name
         expect( subscription.livemode ).to be false
-        expect( subscription.amount ).to be offer.amount
+        expect( subscription.amount.to_s ).to eq offer.amount # bug in API
         expect( subscription.temp_amount ).to be_nil
         expect( subscription.currency ).to eq offer.currency
         expect( subscription.name ).to eq 'To Delete'


### PR DESCRIPTION
JSON response should have proper type already set. Trying convert values to integer leads to bugs like for "last4" attribute with "0042" that would be converted to 42

Relates to #18 

There are still failing tests because of hardcoded ids of resources -> #9 

Also I found that paymill API is returning amount as strings in some cases which is a bug considering the documentation. Should I report it somewhere else?