### PR TITLE
Fixed objectize method for arrays.

### DIFF
--- a/lib/paymill/models/base.rb
+++ b/lib/paymill/models/base.rb
@@ -28,10 +28,10 @@ module Paymill
       json.each_pair do |key, value|
         case value.class.name
         when 'Array'
-          unless key[-1].eql? 's'
-            instance_variable_set( "@#{key}s", value.map { |e| (e.is_a? String) ? e : objectize( key, e ) } )
+          if key.end_with?('s')
+            instance_variable_set( "@#{key}", value.map { |e| (e.is_a? String) ? e : objectize( key[0...-1], e ) } )
           else
-            instance_variable_set( "@#{key}", value.map { |e| (e.is_a? String) ? e : objectize( key, e ) } )
+            instance_variable_set( "@#{key}s", value.map { |e| (e.is_a? String) ? e : objectize( key, e ) } )
           end
         when 'Hash'
           instance_variable_set( "@#{key}", objectize( key, value ) )

--- a/spec/paymill/models/refund_spec.rb
+++ b/spec/paymill/models/refund_spec.rb
@@ -57,6 +57,14 @@ module Paymill
         expect( refund.app_id ).to be_nil
       end
 
+      it 'should return nested refund in transaction object' do
+        transaction = Transaction.create( token: @token, amount: 100, currency: currency )
+        refund = Refund.create( transaction, amount: 100, description: 'Refunded By Ruby' )
+        transaction_with_refund = Transaction.find( transaction.id )
+
+        expect( transaction_with_refund.refunds.first.id ).to eq refund.id
+      end
+
       it 'should throw ArgumentError when no amount given', :vcr do
         expect{ Refund.create( Transaction.create( token: @token, amount: 290, currency: currency ) ) }.to raise_error ArgumentError
       end


### PR DESCRIPTION
Previously when deserializing json, error like
`NameError: uninitialized constant Paymill::Refunds` was raised.

I also switched conditions to avoid `unless else` which is hard to read.

/cc @nikoloff 