### PR TITLE
update_offer_with_refund_and_capture_date

### DIFF
--- a/lib/paymill/models/subscription.rb
+++ b/lib/paymill/models/subscription.rb
@@ -48,7 +48,7 @@ module Paymill
     end
 
     def update_offer_with_refund_and_capture_date( offer )
-      update_offer( offer, 1 )
+      update_offer( offer, 2 )
     end
 
     def stop_trial_period()
@@ -136,7 +136,7 @@ module Paymill
       @amount = nil
       @payment = nil
       @offer = offer
-      update( offer_change_type: 1 )
+      update( offer_change_type: flag )
     end
 
   end

--- a/spec/paymill/models/subscription_spec.rb
+++ b/spec/paymill/models/subscription_spec.rb
@@ -358,10 +358,9 @@ module Paymill
 
       it 'should change the offer of a subscription with no refund and unchanged capture date', :vcr do
         subscription = Subscription.create( payment: @payment, offer: offer )
+        subscription_before_update = subscription.dup
         new_offer = Offer.create( name: 'Foo', amount: 4990, currency: 'EUR', interval: '2 WEEK')
-
         subscription.update_offer_without_changes( new_offer )
-
         expect( subscription.id ).to be_a String
         expect( subscription.offer.amount.to_s ).to eq new_offer.amount # bug in API
         expect( subscription.offer.currency ).to eq new_offer.currency
@@ -378,6 +377,7 @@ module Paymill
         expect( subscription.period_of_validity ).to be_nil
         expect( subscription.end_of_period ).to be_nil
         expect( subscription.next_capture_at ).to be_a Time
+        expect( subscription.next_capture_at ).to eq subscription_before_update.next_capture_at
         expect( subscription.created_at ).to be_a Time
         expect( subscription.updated_at ).to be_a Time
         expect( subscription.canceled_at ).to be_nil
@@ -391,6 +391,7 @@ module Paymill
 
       it 'should change the offer of a subscription with refund and unchanged capture date', :vcr do
         subscription = Subscription.create( payment: @payment, offer: offer )
+        subscription_before_update = subscription.dup
         new_offer = Offer.create( name: 'Foo', amount: 1990, currency: 'EUR', interval: '2 WEEK')
 
         subscription.update_offer_with_refund( new_offer )
@@ -411,6 +412,7 @@ module Paymill
         expect( subscription.period_of_validity ).to be_nil
         expect( subscription.end_of_period ).to be_nil
         expect( subscription.next_capture_at ).to be_a Time
+        expect( subscription.next_capture_at ).to eq subscription_before_update.next_capture_at
         expect( subscription.created_at ).to be_a Time
         expect( subscription.updated_at ).to be_a Time
         expect( subscription.canceled_at ).to be_nil
@@ -424,6 +426,7 @@ module Paymill
 
       it 'should change the offer of a subscription with refund and capture date', :vcr do
         subscription = Subscription.create( payment: @payment, offer: offer )
+        subscription_before_update = subscription.dup
         new_offer = Offer.create( name: 'Foo', amount: 1990, currency: 'EUR', interval: '2 WEEK')
 
         subscription.update_offer_with_refund_and_capture_date( new_offer )
@@ -444,6 +447,7 @@ module Paymill
         expect( subscription.period_of_validity ).to be_nil
         expect( subscription.end_of_period ).to be_nil
         expect( subscription.next_capture_at ).to be_a Time
+        expect( subscription.next_capture_at ).to be < subscription_before_update.next_capture_at
         expect( subscription.created_at ).to be_a Time
         expect( subscription.updated_at ).to be_a Time
         expect( subscription.canceled_at ).to be_nil


### PR DESCRIPTION
Based on Paymill documentation method update_offer_with_refund_and_capture_date should send the offer_change_type attribute with value equal to 2 which means that capture date should be changed immediately and a refund should be given, but in master branch this method is sending value equal to 1 which means that capture date will not be change. 

This pull request fixes that and updates corresponding tests. 