### PR TITLE
Update checksum.rb

### DIFF
--- a/lib/paymill/models/checksum.rb
+++ b/lib/paymill/models/checksum.rb
@@ -18,7 +18,7 @@ module Paymill
     def self.allowed_arguments
       [
         :checksum_type, :amount, :currency, :return_url, :cancel_url, :description,
-        :shipping_address, :billing_address, :items, :shipping_amount, :handling_amount, :client_id,
+        :shipping_address, :billing_address, :items, :shipping_amount, :handling_amount, :client,
         :require_reusable_payment, :reusable_payment_description,
         :fee_amount, :fee_payment, :fee_currency, :app_id
       ]


### PR DESCRIPTION
Hi, I've tried to create a new paypal transaction and bind it to a client.

It seems like the the attribute is called `client` instead of `client_id`
Reference: https://developers.paymill.com/guides/paypal/transactions.html#optional-transaction-details

With this code change paypal associates the payment to the given client instead of creating a new one every time.
