### PR TITLE
Checksum :client instead :client_id

### DIFF
--- a/lib/paymill/models/checksum.rb
+++ b/lib/paymill/models/checksum.rb
@@ -18,7 +18,7 @@ module Paymill
     def self.allowed_arguments
       [
         :checksum_type, :amount, :currency, :return_url, :cancel_url, :description,
-        :shipping_address, :billing_address, :items, :shipping_amount, :handling_amount, :client_id,
+        :shipping_address, :billing_address, :items, :shipping_amount, :handling_amount, :client,
         :require_reusable_payment, :reusable_payment_description,
         :fee_amount, :fee_payment, :fee_currency, :app_id
       ]

--- a/spec/paymill/models/checksum_spec.rb
+++ b/spec/paymill/models/checksum_spec.rb
@@ -47,11 +47,11 @@ module Paymill
       end
 
       it 'should create new checksum with minimum parameters and client', :vcr do
-        checksum = Checksum.create( checksum_type: 'paypal', amount: 4200, currency: 'EUR', description: 'Chuck Testa', return_url: 'https://testa.com', cancel_url: 'https://test.com/cancel', client_id: 'client_c43af14afac0e4f58f90' )
+        checksum = Checksum.create( checksum_type: 'paypal', amount: 4200, currency: 'EUR', description: 'Chuck Testa', return_url: 'https://testa.com', cancel_url: 'https://test.com/cancel', client: 'client_c43af14afac0e4f58f90' )
 
         expect( checksum.action ).to eq 'transaction'
         expect( checksum.checksum ).to be_a String
-        expect( checksum.data ).to eq 'amount=4200&currency=EUR&description=Chuck+Testa&return_url=https%3A%2F%2Ftesta.com&cancel_url=https%3A%2F%2Ftest.com%2Fcancel&client_id=client_c43af14afac0e4f58f90'
+        expect( checksum.data ).to eq 'amount=4200&currency=EUR&description=Chuck+Testa&return_url=https%3A%2F%2Ftesta.com&cancel_url=https%3A%2F%2Ftest.com%2Fcancel&client=client_c43af14afac0e4f58f90'
         expect( checksum.id ).to be_a String
         expect( checksum.type ).to eq 'paypal'
         expect( checksum.app_id ).to be_nil


### PR DESCRIPTION
Hi, I've tried to create a new paypal transaction and bind it to a client.

It seems like the the attribute is called `client` instead of `client_id`
Reference: https://developers.paymill.com/guides/paypal/transactions.html#optional-transaction-details

With this code change paypal associates the payment to the given client instead of creating a new one every time.
